### PR TITLE
fix: Strip Content Security Policy on 304s

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -102,6 +102,10 @@ const handleRequest = async (request, env, ctx) => {
       resp.headers.set('location', `${location}${savedSearch}`);
     }
   }
+  if (resp.status === 304) {
+    // 304 Not Modified - remove CSP header
+    resp.headers.delete('Content-Security-Policy');
+  }
   resp.headers.delete('age');
   resp.headers.delete('x-robots-tag');
   return resp;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

304 Response codes should not contain the `content-security-policy` header, because certain configurations (for example nonces) do not combined with HTML from local browser cache.

The change should not diminish the effectiveness of the content-security-policy mechanism, because the browser must take the cached header from the local cache and apply it.

## Motivation and Context

https://da.live/ was broken intermittently after deploying the recommended CSP configuration with [strict-dynamic and (cached) nonces](https://www.aem.live/docs/csp-strict-dynamic-cached-nonce)

## How Has This Been Tested?

In production with 2 sites using Cloudflare as their BYO CDN.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
