### PR TITLE
Add CUG header handling kickstart with auth hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,23 @@ Authorization: token <token>
 
 All you have to do is set the `ORIGIN_AUTHENTICATION` environment variable in the Cloudflare dashboard to the token you have configured in your AEM project or do the same via wrangler.
 
-## 5. Deploy your site
+## 5. Closed User Groups (CUG) — optional
+
+If your AEM project uses [Closed User Groups](https://www.aem.live/docs/authentication-setup-authentication), the origin sends two headers on protected resources:
+
+- `x-aem-cug-required: true`
+- `x-aem-cug-groups: <comma,separated,group,ids>`
+
+This worker:
+
+1. Strips both headers before forwarding the response — they must never reach the browser.
+2. Calls the `isAuthorized(request, env, allowedGroups)` hook in [`src/index.mjs`](src/index.mjs).
+3. Returns `401 Unauthorized` whenever the hook returns `false`.
+4. Sets `Cache-Control: private, no-store` on authorized CUG responses.
+
+**Authentication is intentionally not implemented in this template.** Plug your identity provider (Adobe IMS, Okta, Auth0, Azure AD, ...) into `isAuthorized` — see the inline comments in `src/index.mjs` for guidance and a full reference implementation (Adobe IMS + OAuth 2.0 + PKCE + JWT session) at [`aemsites/summit-portal/workers/cloudflare/cug-adobe-oauth-worker`](https://github.com/aemsites/summit-portal/tree/main/workers/cloudflare/cug-adobe-oauth-worker).
+
+## 6. Deploy your site
 
 Install `wrangler` (if you haven't done so already):
 
@@ -53,7 +69,7 @@ Publish your site:
 npx wrangler deploy
 ```
 
-## 5. Test your site
+## 7. Test your site
 
 Point your browser to your site (e.g. `https://www.mydomain.com/`).
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ All you have to do is set the `ORIGIN_AUTHENTICATION` environment variable in th
 
 ## 5. Closed User Groups (CUG) — optional
 
-If your AEM project uses [Closed User Groups](https://www.aem.live/docs/authentication-setup-authentication), the origin sends two headers on protected resources:
+If your AEM project uses Closed User Groups, the origin sends two headers on protected resources:
 
 - `x-aem-cug-required: true`
 - `x-aem-cug-groups: <comma,separated,group,ids>`

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -21,6 +21,47 @@ const getExtension = (path) => {
 const isMediaRequest = (url) => /\/media_[0-9a-f]{40,}[/a-zA-Z0-9_-]*\.[0-9a-z]+$/.test(url.pathname);
 const isRUMRequest = (url) => /\/\.(rum|optel)\/.*/.test(url.pathname);
 
+// Closed User Group (CUG) headers sent by the AEM Edge Delivery origin when a
+// resource is protected. These are an origin <-> worker contract and must
+// NEVER be forwarded to the browser (see the strip step below).
+//
+//   x-aem-cug-required: "true" when the resource is part of a closed user group
+//   x-aem-cug-groups:   comma-separated list of group identifiers allowed access
+const CUG_REQUIRED_HEADER = 'x-aem-cug-required';
+const CUG_GROUPS_HEADER = 'x-aem-cug-groups';
+
+/**
+ * Authorization hook for Closed User Group (CUG) protected resources.
+ *
+ * --------------------------------------------------------------------------
+ * AUTHENTICATION IS NOT INCLUDED IN THIS TEMPLATE.
+ * --------------------------------------------------------------------------
+ *
+ * Wire your identity provider in here. A typical implementation would:
+ *   1. Read a signed session cookie / JWT from `request`.
+ *   2. If missing or invalid, redirect to your IdP (Adobe IMS, Okta, Auth0,
+ *      Azure AD, ...) using OAuth 2.0 Authorization Code + PKCE.
+ *   3. On callback, create a signed session and set it as an
+ *      HttpOnly; Secure; SameSite=Lax cookie.
+ *   4. Match the user's claims (e.g. email domain, groups) against
+ *      `allowedGroups` (parsed from x-aem-cug-groups) and return true/false.
+ *
+ * Reference implementation (Adobe IMS + JWT session + Cloudflare KV):
+ *   https://github.com/aemsites/summit-portal/tree/main/workers/cloudflare/cug-adobe-oauth-worker
+ *
+ * Until this is implemented, CUG-protected resources return 401 Unauthorized
+ * — that is the secure default. Never return `true` unconditionally from this
+ * function in production.
+ *
+ * @param {Request} request       the incoming request (use to read cookies)
+ * @param {object}  env           Worker environment (vars, secrets, KV, ...)
+ * @param {string[]} allowedGroups groups allowed by the origin, may be empty
+ * @returns {Promise<boolean>}    true to serve the response, false to deny
+ */
+// eslint-disable-next-line no-unused-vars
+async function isAuthorized(request, env, allowedGroups) {
+  return false;
+}
 
 const handleRequest = async (request, env, ctx) => {
   const url = new URL(request.url);
@@ -95,6 +136,34 @@ const handleRequest = async (request, env, ctx) => {
     },
   });
   resp = new Response(resp.body, resp);
+
+  // --- Closed User Group (CUG) enforcement ---
+  // Read CUG signals from the origin response, then strip them so they never
+  // leak to the browser. If the resource is CUG-protected, delegate the
+  // decision to the `isAuthorized` hook above (which the customer implements
+  // against their identity provider).
+  const cugRequired = resp.headers.get(CUG_REQUIRED_HEADER) === 'true';
+  const cugGroupsHeader = resp.headers.get(CUG_GROUPS_HEADER) || '';
+  resp.headers.delete(CUG_REQUIRED_HEADER);
+  resp.headers.delete(CUG_GROUPS_HEADER);
+
+  if (cugRequired) {
+    const allowedGroups = cugGroupsHeader
+      .split(',')
+      .map((g) => g.trim())
+      .filter(Boolean);
+    const ok = await isAuthorized(request, env, allowedGroups);
+    if (!ok) {
+      // Secure default: deny when auth is not implemented or the user is not
+      // authorized. Replace this with a redirect to your IdP in `isAuthorized`.
+      return new Response('Unauthorized', { status: 401 });
+    }
+    // Authenticated CUG responses are user-specific: prevent caching by the
+    // browser. The AEM origin is expected to also send Cache-Control: private
+    // on CUG resources so the CF edge cache does not retain them.
+    resp.headers.set('Cache-Control', 'private, no-store');
+  }
+
   if (resp.status === 301 && savedSearch) {
     const location = resp.headers.get('location');
     if (location && !location.match(/\?.*$/)) {


### PR DESCRIPTION
## Summary

Minimal scaffolding to help customers kick-start a Cloudflare worker that handles AEM Edge Delivery **Closed User Group (CUG)** responses. Authentication itself is intentionally **not** implemented — only described in comments and the README — so customers have a clear, secure hook point to plug in their identity provider (Adobe IMS, Okta, Auth0, Azure AD, ...).

## What changes

- **`src/index.mjs`**
  - Recognises `x-aem-cug-required` and `x-aem-cug-groups` headers on the origin response.
  - Strips both headers before returning to the browser (they are an origin↔worker contract, never client-facing).
  - Delegates the access decision to a single `isAuthorized(request, env, allowedGroups)` hook.
  - Sets `Cache-Control: private, no-store` on authorized CUG responses.
- **`README.md`**
  - New "5. Closed User Groups (CUG) — optional" section.
  - Fixes the existing duplicate `## 5.` numbering on the Deploy/Test sections (now 6 and 7).
- No new files, no new dependencies, no `wrangler.toml` changes.

## Secure by default

`isAuthorized` returns `false` out of the box, so CUG-protected resources respond with `401 Unauthorized` until the customer wires in their IdP. This aligns with the "fail securely" principle — customers cannot accidentally ship a public site that exposes CUG content.

## Where to plug auth in

The JSDoc on `isAuthorized` in `src/index.mjs` describes the typical flow (Authorization Code + PKCE, signed-session cookie, group/claim mapping) and links to a full reference worker for AEM:

- [`aemsites/summit-portal/workers/cloudflare/cug-adobe-oauth-worker`](https://github.com/aemsites/summit-portal/tree/main/workers/cloudflare/cug-adobe-oauth-worker) — Adobe IMS + OAuth 2.0 + PKCE + JWT session + Cloudflare KV for PKCE state.

## Request flow

```mermaid
flowchart TD
  Req[Browser request] --> Origin[Fetch from ORIGIN_HOSTNAME]
  Origin --> Cug{"x-aem-cug-required: true?"}
  Cug -->|no| Pass[Return response unchanged]
  Cug -->|yes| Strip[Strip CUG headers]
  Strip --> Auth["isAuthorized() hook"]
  Auth -->|false| Unauth[401 Unauthorized]
  Auth -->|true| Private["Cache-Control: private, no-store"]
  Private --> Pass
```

## Test plan

- [ ] Public path (no CUG headers from origin) → unchanged behavior, no `Cache-Control: private, no-store` added.
- [ ] CUG-protected path with default `isAuthorized` → 401 Unauthorized, CUG headers stripped from the response.
- [ ] CUG-protected path with a stub `isAuthorized` returning `true` → original response body served, CUG headers stripped, `Cache-Control: private, no-store` set.
- [ ] Existing behaviour preserved: port redirect, `/drafts/` 404, RUM method allow-list, query-param sanitization, push-invalidation header, ORIGIN_AUTHENTICATION header, 301 query-string restoration, 304 CSP cleanup.

## Notes

- Marked as **draft** for early feedback on shape and naming.
- Adobe CLA may need to be signed on first contribution — a bot will comment if so.

Made with [Cursor](https://cursor.com)